### PR TITLE
globally installing expo-camera and expo-media-library

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
     "@react-navigation/native-stack": "^6.2.5",
     "expo": "~44.0.0",
     "expo-asset": "~8.4.6",
+    "expo-camera": "~12.1.2",
     "expo-font": "~10.0.4",
+    "expo-media-library": "~14.0.0",
     "expo-status-bar": "~1.2.0",
     "firebase": "^9.6.1",
     "react": "17.0.1",
@@ -22,9 +24,7 @@
     "react-native-rapi-ui": "^0.2.1",
     "react-native-safe-area-context": "3.3.2",
     "react-native-screens": "~3.10.1",
-    "react-native-web": "0.17.1",
-    "expo-camera": "~12.1.2",
-    "expo-media-library": "~14.0.0"
+    "react-native-web": "0.17.1"
   },
   "devDependencies": {
     "@babel/core": "^7.12.9"


### PR DESCRIPTION
This commit is to ensure that collaboraters will not have to locally install expo-camera and expo-media-library.